### PR TITLE
Optimized RemoveTransparencyFromImage function for better performance.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ obj/
 .svn/
 *.user
 *.suo
+/.vs

--- a/ASU/BO/ImageUnpacker.cs
+++ b/ASU/BO/ImageUnpacker.cs
@@ -58,7 +58,7 @@ namespace ASU.BO
         private Bitmap RemoveTransparencyFromImage(Bitmap image)
         {
             Dictionary<int, Color> coloursByArgb = new Dictionary<int, Color>();
-            Dictionary<int, Color> transparentPixelsByCoord = new Dictionary<int, Color>();
+            Dictionary<uint, Color> transparentPixelsByCoord = new Dictionary<uint, Color>();
             Dictionary<Color, Color> opaquedByTransparent = new Dictionary<Color, Color>();
             Color pixel;
             bool containsTransparency = false;
@@ -85,7 +85,7 @@ namespace ASU.BO
 
             if (containsTransparency)
             {
-                foreach (int coordHash in transparentPixelsByCoord.Keys)
+                foreach (uint coordHash in transparentPixelsByCoord.Keys)
                 {
                     Point coord = GetCoordFromHash(coordHash);
 
@@ -461,14 +461,14 @@ namespace ASU.BO
             }
         }
 
-        private Point GetCoordFromHash(int hash)
+        private Point GetCoordFromHash(uint hash)
         {
             return new Point((int)(hash >> 16), (int)(hash & 0x0000FFFF));
         }
 
-        private int GetHashFromCoord(Point point)
+        private uint GetHashFromCoord(Point point)
         {
-            return (point.X << 16) + point.Y;
+            return (uint)((point.X << 16) + point.Y);
         }
     }
 }

--- a/ASU/BO/ImageUnpacker.cs
+++ b/ASU/BO/ImageUnpacker.cs
@@ -58,7 +58,7 @@ namespace ASU.BO
         private Bitmap RemoveTransparencyFromImage(Bitmap image)
         {
             Dictionary<int, Color> coloursByArgb = new Dictionary<int, Color>();
-            Dictionary<Point, Color> transparentPixelsByCoord = new Dictionary<Point, Color>();
+            Dictionary<int, Color> transparentPixelsByCoord = new Dictionary<int, Color>();
             Dictionary<Color, Color> opaquedByTransparent = new Dictionary<Color, Color>();
             Color pixel;
             bool containsTransparency = false;
@@ -78,16 +78,18 @@ namespace ASU.BO
                     if (pixel.A < 255)
                     {
                         containsTransparency = true;
-                        transparentPixelsByCoord.Add(new Point(x, y), pixel);
+                        transparentPixelsByCoord.Add(GetHashFromCoord(new Point(x, y)), pixel);
                     }
                 }
             }
 
             if (containsTransparency)
             {
-                foreach (Point coord in transparentPixelsByCoord.Keys)
+                foreach (int coordHash in transparentPixelsByCoord.Keys)
                 {
-                    transparentPixel = transparentPixelsByCoord[coord];
+                    Point coord = GetCoordFromHash(coordHash);
+
+                    transparentPixel = transparentPixelsByCoord[coordHash];
                     if (opaquedByTransparent.ContainsKey(transparentPixel))
                     {
                         opaquedPixel = opaquedByTransparent[transparentPixel];
@@ -457,6 +459,16 @@ namespace ASU.BO
             {
                 UnpackingComplete();
             }
+        }
+
+        private Point GetCoordFromHash(int hash)
+        {
+            return new Point((int)(hash >> 16), (int)(hash & 0x0000FFFF));
+        }
+
+        private int GetHashFromCoord(Point point)
+        {
+            return (point.X << 16) + point.Y;
         }
     }
 }


### PR DESCRIPTION
In the original code, the dictionary transparentPixelsByCoord used a Point as a key. For whatever reason, this causes a significant overhead whenever transparentPixelsByCoord.Add is called. With a large image that has many transparent pixels, the function can take tens of seconds to process. I changed the key type for this dictionary to uint, and created two functions to convert a Point into a uint and back. The x coordinate is stored in the upper region of the int and the y coordinate in the lower. The only limitation with this is that an image can not be bigger than 65535x65535, though I would imagine that in most instances such large images would not be used. However, if bigger resolutions are needed, a ulong can be used instead of an int.